### PR TITLE
Replace `npm install` with `yarn install` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Development is done on the `master` branch. We attempt to do our best to ensure 
    ```
 2. Install all necessary dependencies:
    ```bash
-   npm install
+   yarn install
    ```
 3. Build the project for the first time:
    ```bash


### PR DESCRIPTION
`yarn` is used by this project, so dependencies should be installed with `yarn`.

I got errors running `npm install` in my fork.