### PR TITLE
Add cherry-picking automation

### DIFF
--- a/.github/workflows/cherry-pick-pr-for-label.yml
+++ b/.github/workflows/cherry-pick-pr-for-label.yml
@@ -1,0 +1,14 @@
+name: Cherry pick PR commits for label
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  cherry_pick_pr_for_label:
+    name: Cherry pick PR commits for label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cherry Pick PR for label
+        uses: kurrent-io/Automations/cherry-pick-pr-for-label@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ distributed messaging challenges and ensures data consistency.
 This monorepo contains the following packages:
 
 | Subfolder                                            | Package                                                                                |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+|------------------------------------------------------|----------------------------------------------------------------------------------------|
 | [`packages/db-client/`](packages/db-client/)         | [`@kurrent/kurrentdb-client`](https://www.npmjs.com/package/@kurrent/kurrentdb-client) |
 | [`packages/opentelemetry/`](packages/opentelemetry/) | [`@kurrent/opentelemetry`](https://www.npmjs.com/package/@kurrent/opentelemetry)       |
 | [`packages/test/`](packages/test/)                   | Internal tests                                                                         |


### PR DESCRIPTION
To be able to back-port changes to supported previous releases, we are switching to release branches. Therefore, we need to automate the process of propagating changes to past releases using cherry-picking labels. This PR adds the automation job with GitHub Actions.