### PR TITLE
Make resolved commit position from bridge client a big int

### DIFF
--- a/packages/db-client/src/utils/convertRustEvent.ts
+++ b/packages/db-client/src/utils/convertRustEvent.ts
@@ -22,7 +22,7 @@ export const convertRustEvent = <T extends ResolvedEvent>(
   }
 
   if (rustClient.commitPosition != undefined) {
-    resolved.commitPosition = rustClient.commitPosition;
+    resolved.commitPosition = BigInt(rustClient.commitPosition);
   }
 
   return resolved as T;

--- a/packages/test/src/streams/readAll.test.ts
+++ b/packages/test/src/streams/readAll.test.ts
@@ -168,6 +168,7 @@ describe("readAll", () => {
       // resolved event
       expect(doResolveEvent.event).toBeDefined();
       expect(doResolveEvent.event?.type).toBe("linky");
+      expect(typeof doResolveEvent.commitPosition).toBe("bigint");
 
       // link event
       expect(doResolveEvent.link).toBeDefined();

--- a/packages/test/src/streams/readStream.test.ts
+++ b/packages/test/src/streams/readStream.test.ts
@@ -295,6 +295,7 @@ describe("readStream", () => {
         expect(resolvedEvent.event?.position?.prepare).toBe(
           appendResult.position?.prepare
         );
+        expect(typeof resolvedEvent.commitPosition).toBe("bigint");
       });
     });
   });


### PR DESCRIPTION
Fix: https://github.com/kurrent-io/KurrentDB-Client-NodeJS/issues/423