### PR TITLE
[DEV-863] Support PinnedByCorrelation in create persistent subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "18.19.76",
+    "@types/semver": "^7.7.0",
     "@typescript-eslint/eslint-plugin": "^8.10.0",
     "@typescript-eslint/parser": "^8.10.0",
     "cross-env": "^7.0.3",
@@ -31,7 +32,7 @@
     "eslint-plugin-tsdoc": "^0.2.17",
     "nx": "20.1.3",
     "prettier": "^2.8.8",
-    "semver": "^7.6.3",
+    "semver": "^7.7.2",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/db-client/package.json
+++ b/packages/db-client/package.json
@@ -52,9 +52,11 @@
     "@types/node": "^22.10.2",
     "debug": "^4.4.0",
     "google-protobuf": "^3.21.4",
+    "semver": "^7.7.2",
     "uuid": "11.0.3"
   },
   "devDependencies": {
+    "@types/semver": "^7.7.0",
     "@types/uuid": "^10.0.0",
     "grpc-tools": "^1.12.4",
     "grpc_tools_node_protoc_ts": "^5.3.3",

--- a/packages/db-client/src/constants.ts
+++ b/packages/db-client/src/constants.ts
@@ -21,6 +21,7 @@ export const READ_ONLY_REPLICA = "read_only_replica";
 export const DISPATCH_TO_SINGLE = "DispatchToSingle";
 export const ROUND_ROBIN = "RoundRobin";
 export const PINNED = "Pinned";
+export const PINNED_BY_CORRELATION = "PinnedByCorrelation";
 
 // persistent action
 export const PARK = "park";

--- a/packages/db-client/src/persistentSubscription/createPersistentSubscriptionToAll.ts
+++ b/packages/db-client/src/persistentSubscription/createPersistentSubscriptionToAll.ts
@@ -44,20 +44,22 @@ Client.prototype.createPersistentSubscriptionToAll = async function (
   this: Client,
   groupName: string,
   settings: PersistentSubscriptionToAllSettings,
-  {
-    filter,
-
-    ...baseOptions
-  }: CreatePersistentSubscriptionToAllOptions = {}
+  { filter, ...baseOptions }: CreatePersistentSubscriptionToAllOptions = {}
 ): Promise<void> {
-  if (!(await this.supports(PersistentSubscriptionsService.create, "all"))) {
+  const capabilities = await this.capabilities;
+
+  if (!capabilities.supports(PersistentSubscriptionsService.create, "all")) {
     throw new UnsupportedError("createPersistentSubscriptionToAll", "21.10");
   }
 
   const req = new CreateReq();
   const options = new CreateReq.Options();
   const allOptions = new CreateReq.AllOptions();
-  const reqSettings = settingsToGRPC(settings, CreateReq.Settings);
+  const reqSettings = settingsToGRPC(
+    settings,
+    CreateReq.Settings,
+    capabilities
+  );
 
   switch (settings.startFrom) {
     case START: {

--- a/packages/db-client/src/persistentSubscription/createPersistentSubscriptionToStream.ts
+++ b/packages/db-client/src/persistentSubscription/createPersistentSubscriptionToStream.ts
@@ -37,10 +37,16 @@ Client.prototype.createPersistentSubscriptionToStream = async function (
   settings: PersistentSubscriptionToStreamSettings,
   baseOptions: BaseOptions = {}
 ): Promise<void> {
+  const capabilities = await this.capabilities;
+
   const req = new CreateReq();
   const options = new CreateReq.Options();
   const identifier = createStreamIdentifier(streamName);
-  const reqSettings = settingsToGRPC(settings, CreateReq.Settings);
+  const reqSettings = settingsToGRPC(
+    settings,
+    CreateReq.Settings,
+    capabilities
+  );
 
   // Add deprecated revision option for pre-21.10 support
   switch (settings.startFrom) {

--- a/packages/db-client/src/persistentSubscription/utils/settingsToGRPC.ts
+++ b/packages/db-client/src/persistentSubscription/utils/settingsToGRPC.ts
@@ -2,10 +2,13 @@ import {
   CreateReq,
   UpdateReq,
 } from "../../../generated/kurrentdb/protocols/v1/persistentsubscriptions_pb";
+import { ServerFeatures } from "../../Client/ServerFeatures";
+import semver from "semver";
 
 import {
   DISPATCH_TO_SINGLE,
   PINNED,
+  PINNED_BY_CORRELATION,
   ROUND_ROBIN,
   UNBOUNDED,
 } from "../../constants";
@@ -14,6 +17,7 @@ import type {
   PersistentSubscriptionToStreamSettings,
   PersistentSubscriptionToAllSettings,
 } from "./persistentSubscriptionSettings";
+import { UnsupportedError } from "../../utils";
 
 type GRPCSettings = typeof CreateReq.Settings | typeof UpdateReq.Settings;
 
@@ -21,7 +25,8 @@ export const settingsToGRPC = <T extends GRPCSettings>(
   settings:
     | PersistentSubscriptionToStreamSettings
     | PersistentSubscriptionToAllSettings,
-  ReqSettings: T
+  ReqSettings: T,
+  capabilities?: ServerFeatures
 ): InstanceType<T> => {
   const reqSettings = new ReqSettings() as InstanceType<T>;
 
@@ -48,28 +53,39 @@ export const settingsToGRPC = <T extends GRPCSettings>(
   reqSettings.setReadBatchSize(settings.readBatchSize);
   reqSettings.setHistoryBufferSize(settings.historyBufferSize);
 
-  switch (settings.consumerStrategyName) {
-    case DISPATCH_TO_SINGLE: {
-      reqSettings.setNamedConsumerStrategy(
-        CreateReq.ConsumerStrategy.DISPATCHTOSINGLE
-      );
-      break;
-    }
-    case PINNED: {
-      reqSettings.setNamedConsumerStrategy(CreateReq.ConsumerStrategy.PINNED);
-      break;
-    }
-    case ROUND_ROBIN: {
-      reqSettings.setNamedConsumerStrategy(
-        CreateReq.ConsumerStrategy.ROUNDROBIN
-      );
-      break;
-    }
-    default: {
-      console.warn(
-        `Unknown consumerStrategyName ${settings.consumerStrategyName}.`
-      );
-      break;
+  if (
+    capabilities &&
+    semver.satisfies(capabilities.serverVersion, ">=21.10.1") &&
+    reqSettings instanceof CreateReq.Settings
+  ) {
+    reqSettings.setConsumerStrategy(settings.consumerStrategyName);
+  } else {
+    switch (settings.consumerStrategyName) {
+      case DISPATCH_TO_SINGLE: {
+        reqSettings.setNamedConsumerStrategy(
+          CreateReq.ConsumerStrategy.DISPATCHTOSINGLE
+        );
+        break;
+      }
+      case PINNED: {
+        reqSettings.setNamedConsumerStrategy(CreateReq.ConsumerStrategy.PINNED);
+        break;
+      }
+      case ROUND_ROBIN: {
+        reqSettings.setNamedConsumerStrategy(
+          CreateReq.ConsumerStrategy.ROUNDROBIN
+        );
+        break;
+      }
+      case PINNED_BY_CORRELATION: {
+        throw new UnsupportedError(PINNED_BY_CORRELATION, "21.10.1");
+      }
+      default: {
+        console.warn(
+          `Unknown consumerStrategyName ${settings.consumerStrategyName}.`
+        );
+        break;
+      }
     }
   }
 

--- a/packages/db-client/src/types/index.ts
+++ b/packages/db-client/src/types/index.ts
@@ -247,7 +247,8 @@ export interface DeleteResult {
 export type ConsumerStrategy =
   | typeof constants.DISPATCH_TO_SINGLE
   | typeof constants.ROUND_ROBIN
-  | typeof constants.PINNED;
+  | typeof constants.PINNED
+  | typeof constants.PINNED_BY_CORRELATION;
 
 export type PersistentAction =
   | typeof constants.PARK

--- a/packages/test/src/persistentSubscription/createPersistentSubscriptionToAll.test.ts
+++ b/packages/test/src/persistentSubscription/createPersistentSubscriptionToAll.test.ts
@@ -14,6 +14,7 @@ import {
   persistentSubscriptionToAllSettingsFromDefaults,
   START,
   UnsupportedError,
+  PINNED_BY_CORRELATION,
 } from "@kurrent/kurrentdb-client";
 
 describe("createPersistentSubscriptionToAll", () => {
@@ -85,6 +86,43 @@ describe("createPersistentSubscriptionToAll", () => {
             })
           )
         ).resolves.toBeUndefined();
+      });
+
+      test("valid consumer strategy", async () => {
+        const GROUP_NAME = "group_name_valid_consumer_strategy";
+        await expect(
+          client.createPersistentSubscriptionToAll(
+            GROUP_NAME,
+            persistentSubscriptionToAllSettingsFromDefaults({
+              consumerStrategyName: PINNED_BY_CORRELATION,
+            })
+          )
+        ).resolves.toBeUndefined();
+
+        let persistentSubscriptions =
+          await client.listAllPersistentSubscriptions();
+
+        persistentSubscriptions = persistentSubscriptions.filter(
+          (ps) => ps.groupName === GROUP_NAME
+        );
+
+        expect(persistentSubscriptions).toHaveLength(1);
+        expect(persistentSubscriptions[0].groupName).toBe(GROUP_NAME);
+        expect(persistentSubscriptions[0].settings.consumerStrategyName).toBe(
+          PINNED_BY_CORRELATION
+        );
+      });
+
+      test("invalid consumer strategy", async () => {
+        const GROUP_NAME = "group_name_invalid_consumer_strategy";
+        await expect(
+          client.createPersistentSubscriptionToAll(
+            GROUP_NAME,
+            persistentSubscriptionToAllSettingsFromDefaults({
+              consumerStrategyName: "strategy_does_not_exists",
+            })
+          )
+        ).rejects.toThrow(Error);
       });
 
       test("with a filter", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,12 +1130,14 @@ __metadata:
     "@types/debug": "npm:^4.1.12"
     "@types/google-protobuf": "npm:^3.15.12"
     "@types/node": "npm:^22.10.2"
+    "@types/semver": "npm:^7.7.0"
     "@types/uuid": "npm:^10.0.0"
     debug: "npm:^4.4.0"
     google-protobuf: "npm:^3.21.4"
     grpc-tools: "npm:^1.12.4"
     grpc_tools_node_protoc_ts: "npm:^5.3.3"
     nx: "npm:20.1.3"
+    semver: "npm:^7.7.2"
     shx: "npm:^0.3.4"
     uuid: "npm:11.0.3"
   languageName: unknown
@@ -1936,6 +1938,13 @@ __metadata:
   version: 2.4.34
   resolution: "@types/seedrandom@npm:2.4.34"
   checksum: 10c0/de045c55f07270ee300c4f33de0724b69cea9f3597047b53b039b43d4b21c4a40d5f13fe29f2b69a857f124048c4b58bf92ab5faf5816c21c5b2eb4e803cfae6
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.7.0":
+  version: 7.7.0
+  resolution: "@types/semver@npm:7.7.0"
+  checksum: 10c0/6b5f65f647474338abbd6ee91a6bbab434662ddb8fe39464edcbcfc96484d388baad9eb506dff217b6fc1727a88894930eb1f308617161ac0f376fe06be4e1ee
   languageName: node
   linkType: hard
 
@@ -7169,6 +7178,7 @@ __metadata:
   dependencies:
     "@tsconfig/node18": "npm:^18.2.4"
     "@types/node": "npm:18.19.76"
+    "@types/semver": "npm:^7.7.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.10.0"
     "@typescript-eslint/parser": "npm:^8.10.0"
     cross-env: "npm:^7.0.3"
@@ -7176,7 +7186,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.2.17"
     nx: "npm:20.1.3"
     prettier: "npm:^2.8.8"
-    semver: "npm:^7.6.3"
+    semver: "npm:^7.7.2"
     typescript: "npm:^5.6.3"
   languageName: unknown
   linkType: soft
@@ -9574,6 +9584,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.2":
+  version: 7.7.2
+  resolution: "semver@npm:7.7.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/aca305edfbf2383c22571cb7714f48cadc7ac95371b4b52362fb8eeffdfbc0de0669368b82b2b15978f8848f01d7114da65697e56cd8c37b0dab8c58e543f9ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PinnedByCorrelation name strategy was added in server version 21.10.1, but clients never supported it because they were unable to update it after creation. Starting with the next major release, we will no longer provide the ability to update a consumer strategy when updating a persistent subscription. Users should instead create a new persistent subscription.