### PR TITLE
Drop `uuid` and bump vulnerable transitives for `@kurrent/kurrentdb-client`

### DIFF
--- a/packages/db-client/package.json
+++ b/packages/db-client/package.json
@@ -52,12 +52,10 @@
     "@types/node": "^22.10.2",
     "debug": "^4.4.0",
     "google-protobuf": "^3.21.4",
-    "semver": "^7.7.2",
-    "uuid": "11.0.3"
+    "semver": "^7.7.2"
   },
   "devDependencies": {
     "@types/semver": "^7.7.0",
-    "@types/uuid": "^10.0.0",
     "grpc-tools": "^1.13.1",
     "grpc_tools_node_protoc_ts": "^5.3.3",
     "nx": "20.1.3",

--- a/packages/db-client/src/Client/index.ts
+++ b/packages/db-client/src/Client/index.ts
@@ -3,7 +3,7 @@ import { isAbsolute, resolve } from "path";
 import { Readable, Writable, Duplex, finished } from "stream";
 import * as bridge from "@kurrent/bridge";
 
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "crypto";
 
 import {
   CallCredentials as grpcCallCredentials,
@@ -320,7 +320,7 @@ export class Client {
       keepAliveInterval = 10_000,
       keepAliveTimeout = 10_000,
       defaultDeadline = 10_000,
-      connectionName = uuid(),
+      connectionName = randomUUID(),
       ...connectionSettings
     }: ConnectionSettings,
     channelCredentials: ChannelCredentialOptions = { insecure: false },

--- a/packages/db-client/src/events/binaryEvent.ts
+++ b/packages/db-client/src/events/binaryEvent.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "crypto";
 
 import type { BinaryEventType, EventData } from "../types";
 
@@ -19,7 +19,7 @@ export const binaryEvent = <E extends BinaryEventType = BinaryEventType>({
   type,
   data,
   metadata,
-  id = uuid(),
+  id = randomUUID(),
 }: BinaryEventOptions<E>): EventData<E> =>
   ({
     id,

--- a/packages/db-client/src/events/jsonEvent.ts
+++ b/packages/db-client/src/events/jsonEvent.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "crypto";
 
 import type { EventData, JSONEventType } from "../types";
 
@@ -15,7 +15,7 @@ export const jsonEvent = <E extends JSONEventType>({
   type,
   data,
   metadata,
-  id = uuid(),
+  id = randomUUID(),
 }: JSONEventOptions<E>): EventData<E> =>
   ({
     id,

--- a/packages/db-client/src/streams/appendToStream/batchAppend.ts
+++ b/packages/db-client/src/streams/appendToStream/batchAppend.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "crypto";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
 import { StreamsClient } from "../../../generated/kurrentdb/protocols/v1/streams_grpc_pb";
@@ -50,7 +50,7 @@ export const batchAppend = async function (
     ...baseOptions
   }: InternalOptions<AppendToStreamOptions>
 ): Promise<AppendResult> {
-  const correlationId = uuid();
+  const correlationId = randomUUID();
 
   const stream = await this.GRPCStreamCreator(
     StreamsClient,

--- a/packages/db-client/src/utils/grpcUUID.ts
+++ b/packages/db-client/src/utils/grpcUUID.ts
@@ -1,7 +1,7 @@
-import { stringify, v4 } from "uuid";
+import { randomUUID } from "crypto";
 import { UUID } from "../../generated/kurrentdb/protocols/v1/shared_pb";
 
-export const createUUID = (id: string = v4()): UUID => {
+export const createUUID = (id: string = randomUUID()): UUID => {
   const uuid = new UUID();
   uuid.setString(id);
   return uuid;
@@ -13,19 +13,21 @@ export function parseUUID(uuid: UUID | undefined): string | undefined {
   if (!uuid) return undefined;
 
   if (uuid.hasStructured()) {
-    const structured = uuid.getStructured()!;
-    const leastSignificantBits = BigInt(structured.getLeastSignificantBits());
-    const mostSignificantBits = BigInt(structured.getMostSignificantBits());
-    const buffer = new ArrayBuffer(16);
-    const dataView = new DataView(buffer);
-
-    dataView.setBigUint64(0, mostSignificantBits);
-    dataView.setBigUint64(8, leastSignificantBits);
-
-    const uint8Array = new Uint8Array(buffer);
-
-    return stringify(uint8Array);
+    return structuredUUIDToString(uuid.getStructured()!);
   }
 
   return uuid.getString();
 }
+
+export const structuredUUIDToString = (structured: UUID.Structured): string => {
+  const ms = toUnsignedHex(structured.getMostSignificantBits());
+  const ls = toUnsignedHex(structured.getLeastSignificantBits());
+  return `${ms.slice(0, 8)}-${ms.slice(8, 12)}-${ms.slice(12)}-${ls.slice(
+    0,
+    4
+  )}-${ls.slice(4)}`;
+};
+
+const U64_MASK = (1n << 64n) - 1n;
+const toUnsignedHex = (value: string): string =>
+  (BigInt(value) & U64_MASK).toString(16).padStart(16, "0");

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -42,7 +42,6 @@
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.14",
-    "@types/uuid": "^9.0.8",
     "cross-env": "^7.0.3",
     "debug": "^4.4.0",
     "docker-compose": "^0.24.8",
@@ -51,7 +50,6 @@
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "shx": "^0.3.4",
-    "ts-jest": "^29.2.5",
-    "uuid": "11.0.3"
+    "ts-jest": "^29.2.5"
   }
 }

--- a/packages/test/src/connection/determineBestNode.test.ts
+++ b/packages/test/src/connection/determineBestNode.test.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 import {
   FOLLOWER,

--- a/packages/test/src/extra/dispose.test.ts
+++ b/packages/test/src/extra/dispose.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment ./src/utils/enableVersionCheck.ts */
 
 import type { Stream } from "stream";
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 import {
   createTestNode,

--- a/packages/test/src/extra/grpcUUID.test.ts
+++ b/packages/test/src/extra/grpcUUID.test.ts
@@ -1,0 +1,48 @@
+import {
+  parseUUID,
+  structuredUUIDToString,
+} from "@kurrent/kurrentdb-client/dist/utils/grpcUUID";
+import { UUID } from "@kurrent/kurrentdb-client/generated/kurrentdb/protocols/v1/shared_pb";
+
+const makeStructured = (msb: string, lsb: string): UUID.Structured => {
+  const s = new UUID.Structured();
+  s.setMostSignificantBits(msb);
+  s.setLeastSignificantBits(lsb);
+  return s;
+};
+
+describe("grpcUUID", () => {
+  describe("structuredUUIDToString", () => {
+    test.each([
+      ["0", "0", "00000000-0000-0000-0000-000000000000"],
+      ["-1", "-1", "ffffffff-ffff-ffff-ffff-ffffffffffff"],
+      ["-9223372036854775808", "0", "80000000-0000-0000-0000-000000000000"],
+      ["0", "-9223372036854775808", "00000000-0000-0000-8000-000000000000"],
+      [
+        "81985529216486895",
+        "81985529216486895",
+        "01234567-89ab-cdef-0123-456789abcdef",
+      ],
+    ])("msb=%s lsb=%s -> %s", (msb, lsb, expected) => {
+      expect(structuredUUIDToString(makeStructured(msb, lsb))).toBe(expected);
+    });
+  });
+
+  describe("parseUUID", () => {
+    test("returns undefined when given undefined", () => {
+      expect(parseUUID(undefined)).toBeUndefined();
+    });
+
+    test("returns the string form unchanged", () => {
+      const u = new UUID();
+      u.setString("01234567-89ab-cdef-0123-456789abcdef");
+      expect(parseUUID(u)).toBe("01234567-89ab-cdef-0123-456789abcdef");
+    });
+
+    test("decodes structured form with high bit set", () => {
+      const u = new UUID();
+      u.setStructured(makeStructured("-1", "-1"));
+      expect(parseUUID(u)).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    });
+  });
+});

--- a/packages/test/src/extra/http2-assertion-failure.test.ts
+++ b/packages/test/src/extra/http2-assertion-failure.test.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 import { createInsecureTestNode, delay, jsonTestEvents } from "@test-utils";
 import {
   KurrentDBClient,

--- a/packages/test/src/extra/typedEvents-more.test.ts
+++ b/packages/test/src/extra/typedEvents-more.test.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 import { createTestNode } from "@test-utils";
 import {

--- a/packages/test/src/opentelemetry/instrumentation.test.ts
+++ b/packages/test/src/opentelemetry/instrumentation.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import { KurrentDBInstrumentation } from "@kurrent/opentelemetry";
 import { KurrentAttributes } from "@kurrent/opentelemetry/dist/attributes";
-import { v4 } from "uuid";
+import { randomUUID as v4 } from "crypto";
 import { collect } from "@test-utils";
 
 const tracerProvider = new NodeTracerProvider();

--- a/packages/test/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.test.ts
+++ b/packages/test/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.test.ts
@@ -3,7 +3,7 @@
 import { pipeline, Writable, Readable, Transform } from "stream";
 import { promisify } from "util";
 
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 import {
   createTestCluster,

--- a/packages/test/src/samples/appending-events.ts
+++ b/packages/test/src/samples/appending-events.ts
@@ -9,7 +9,7 @@ import {
   WrongExpectedVersionError,
 } from "@kurrent/kurrentdb-client";
 import { createTestNode } from "@test-utils";
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 describe("[sample] appending-events", () => {
   const node = createTestNode();

--- a/packages/test/src/samples/get-started.ts
+++ b/packages/test/src/samples/get-started.ts
@@ -6,7 +6,7 @@ import {
   JSONEventType,
 } from "@kurrent/kurrentdb-client";
 import { optionalDescribe } from "@test-utils";
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 const CLOUD_ID = process.env.EVENTSTORE_CLOUD_ID!;
 const STREAM_NAME = uuid();

--- a/packages/test/src/samples/opentelemetry.ts
+++ b/packages/test/src/samples/opentelemetry.ts
@@ -30,7 +30,7 @@ import {
 
 import * as kurrentdb from "@kurrent/kurrentdb-client";
 import { KurrentAttributes } from "@kurrent/opentelemetry/src/attributes";
-import { v4 } from "uuid";
+import { randomUUID as v4 } from "crypto";
 import { multiStreamAppend } from "@kurrent/kurrentdb-client/src/streams/appendToStream/multiStreamAppend";
 import { appendRecords } from "@kurrent/kurrentdb-client/src/streams/appendToStream/appendRecords";
 import {

--- a/packages/test/src/samples/projection-management.ts
+++ b/packages/test/src/samples/projection-management.ts
@@ -1,6 +1,6 @@
 /** @jest-environment ./src/utils/enableVersionCheck.ts */
 
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 import { KurrentDBClient, isCommandError } from "@kurrent/kurrentdb-client";
 import {

--- a/packages/test/src/samples/user-certificates.ts
+++ b/packages/test/src/samples/user-certificates.ts
@@ -1,6 +1,6 @@
 import { KurrentDBClient } from "@kurrent/kurrentdb-client";
 import { createTestNode, jsonTestEvents } from "@test-utils";
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 
 const STREAM_NAME = uuid();
 

--- a/packages/test/src/streams/appendRecords.test.ts
+++ b/packages/test/src/streams/appendRecords.test.ts
@@ -20,7 +20,7 @@ import {
   jsonEvent,
 } from "@kurrent/kurrentdb-client";
 
-import { v4 } from "uuid";
+import { randomUUID as v4 } from "crypto";
 
 describe("appendRecords", () => {
   const supported = matchServerVersion`>=26.0`;

--- a/packages/test/src/streams/multiAppendStream.test.ts
+++ b/packages/test/src/streams/multiAppendStream.test.ts
@@ -21,7 +21,7 @@ import {
   binaryEvent,
 } from "@kurrent/kurrentdb-client";
 
-import { v4 } from "uuid";
+import { randomUUID as v4 } from "crypto";
 
 describe("multiAppend", () => {
   const supported = matchServerVersion`>=25.0`;

--- a/packages/test/src/utils/Cluster.ts
+++ b/packages/test/src/utils/Cluster.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import { promisify } from "util";
 import * as cp from "child_process";
 
-import { v4 as uuid } from "uuid";
+import { randomUUID as uuid } from "crypto";
 import getPort from "get-port";
 import { upAll, down, exec, stopOne, logs } from "docker-compose/dist/v2";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5152,12 +5152,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.15.6":
-  version: 1.15.9
-  resolution: "follow-redirects@npm:1.15.9"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/5829165bd112c3c0e82be6c15b1a58fa9dcfaede3b3c54697a82fe4a62dd5ae5e8222956b448d2f98e331525f05d00404aba7d696de9e761ef6e42fdc780244f
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8913,9 +8913,9 @@ __metadata:
   linkType: hard
 
 "protocol-buffers-schema@npm:^3.1.1":
-  version: 3.6.0
-  resolution: "protocol-buffers-schema@npm:3.6.0"
-  checksum: 10c0/23a08612e5cc903f917ae3b680216ccaf2d889c61daa68d224237f455182fa96fff16872ac94b1954b5dd26fc7e8ce7e9360c54d54ea26218d107b2f059fca37
+  version: 3.6.1
+  resolution: "protocol-buffers-schema@npm:3.6.1"
+  checksum: 10c0/e0a6858d085aa1a6719c924c0be52000dafc24bf3b0d0b1a6e1e68c8b95f8efe3d4069902e14270a2101f2144374eeefc11381dff07ad9909386a4fbc70c7ebd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,7 +1155,6 @@ __metadata:
     "@types/google-protobuf": "npm:^3.15.12"
     "@types/node": "npm:^22.10.2"
     "@types/semver": "npm:^7.7.0"
-    "@types/uuid": "npm:^10.0.0"
     debug: "npm:^4.4.0"
     google-protobuf: "npm:^3.21.4"
     grpc-tools: "npm:^1.13.1"
@@ -1163,7 +1162,6 @@ __metadata:
     nx: "npm:20.1.3"
     semver: "npm:^7.7.2"
     shx: "npm:^0.3.4"
-    uuid: "npm:11.0.3"
   languageName: unknown
   linkType: soft
 
@@ -2011,20 +2009,6 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^9.0.8":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
   languageName: node
   linkType: hard
 
@@ -10339,7 +10323,6 @@ __metadata:
     "@opentelemetry/semantic-conventions": "npm:^1.28.0"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.14"
-    "@types/uuid": "npm:^9.0.8"
     cross-env: "npm:^7.0.3"
     debug: "npm:^4.4.0"
     docker-compose: "npm:^0.24.8"
@@ -10349,7 +10332,6 @@ __metadata:
     jest-environment-node: "npm:^29.7.0"
     shx: "npm:^0.3.4"
     ts-jest: "npm:^29.2.5"
-    uuid: "npm:11.0.3"
   languageName: unknown
   linkType: soft
 
@@ -10937,15 +10919,6 @@ __metadata:
   version: 1.1.0
   resolution: "uuid-parse@npm:1.1.0"
   checksum: 10c0/513d5b0407b8929c54d452e8e286a1f6f00d40a2ebf6607fc7297b9caa40eee35230dcc4ce3f178f84d89704e8147e24d1a33d680a8afb7e12a5700714db7f51
-  languageName: node
-  linkType: hard
-
-"uuid@npm:11.0.3":
-  version: 11.0.3
-  resolution: "uuid@npm:11.0.3"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/cee762fc76d949a2ff9205770334699e0043d52bb766472593a25f150077c9deed821230251ea3d6ab3943a5ea137d2826678797f1d5f6754c7ce5ce27e9f7a6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8861,9 +8861,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.3, protobufjs@npm:^7.2.5":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
+"protobufjs@npm:^7.2.3, protobufjs@npm:^7.2.5, protobufjs@npm:^7.5.3":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -8877,27 +8877,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/a5460a63fe596523b9a067cbce39a6b310d1a71750fda261f076535662aada97c24450e18c5bc98a27784f70500615904ff1227e1742183509f0db4fdede669b
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,13 +2600,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.7.4":
-  version: 1.7.9
-  resolution: "axios@npm:1.7.9"
+  version: 1.15.1
+  resolution: "axios@npm:1.15.1"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/b7a41e24b59fee5f0f26c1fc844b45b17442832eb3a0fb42dd4f1430eb4abc571fe168e67913e8a1d91c993232bd1d1ab03e20e4d1fee8c6147649b576fc1b0b
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/f8b5f3aa954cc1da283e32ad81882967a371dfec7dcc75174fcae93093daeb5399aec2ec587d04779f46b00ff1c297ac9edf3fa596452d6a3d455ce5b58093a4
   languageName: node
   linkType: hard
 
@@ -4521,6 +4521,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
 "es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14":
   version: 0.10.64
   resolution: "es5-ext@npm:0.10.64"
@@ -5151,7 +5163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.11":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
@@ -5195,6 +5207,19 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/bb102d570be8592c23f4ea72d7df9daa50c7792eb0cf1c5d7e506c1706e7426a4e4ae48a35b109e91c85f1c0ec63774a21ae252b66f4eb981cb8efef7d0463c8
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 
@@ -8915,10 +8940,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,37 +670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.14.3":
+"@grpc/grpc-js@npm:^1.14.3, @grpc/grpc-js@npm:^1.7.1, @grpc/grpc-js@npm:^1.9.12":
   version: 1.14.3
   resolution: "@grpc/grpc-js@npm:1.14.3"
   dependencies:
     "@grpc/proto-loader": "npm:^0.8.0"
     "@js-sdsl/ordered-map": "npm:^4.4.2"
   checksum: 10c0/f41f06a311b93cca8c472d56e21387e0f7b57bb2337a91d15ea4279bac8ec4fa0de6bd0d881201229ab800c0f0c55277911ecb850e057f20a828d0ddd623551d
-  languageName: node
-  linkType: hard
-
-"@grpc/grpc-js@npm:^1.7.1, @grpc/grpc-js@npm:^1.9.12":
-  version: 1.12.6
-  resolution: "@grpc/grpc-js@npm:1.12.6"
-  dependencies:
-    "@grpc/proto-loader": "npm:^0.7.13"
-    "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10c0/4d74d573bdb5d5175d54f5613a921ffca6adb38aefa06992d40763d723f64b87842d8019b8bfcbfb9ec1994a67dfbacca976d8f24fedd858c82ea73d538d67df
-  languageName: node
-  linkType: hard
-
-"@grpc/proto-loader@npm:^0.7.13":
-  version: 0.7.13
-  resolution: "@grpc/proto-loader@npm:0.7.13"
-  dependencies:
-    lodash.camelcase: "npm:^4.3.0"
-    long: "npm:^5.0.0"
-    protobufjs: "npm:^7.2.5"
-    yargs: "npm:^17.7.2"
-  bin:
-    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
-  checksum: 10c0/dc8ed7aa1454c15e224707cc53d84a166b98d76f33606a9f334c7a6fb1aedd3e3614dcd2c2b02a6ffaf140587d19494f93b3a56346c6c2e26bc564f6deddbbf3
   languageName: node
   linkType: hard
 
@@ -1640,14 +1616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/semantic-conventions@npm:^1.28.0":
-  version: 1.30.0
-  resolution: "@opentelemetry/semantic-conventions@npm:1.30.0"
-  checksum: 10c0/0bf99552e3b4b7e8b7eb504b678d52f59c6f259df88e740a2011a0d858e523d36fee86047ae1b7f45849c77f00f970c3059ba58e0a06a7d47d6f01dbe8c455bd
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/semantic-conventions@npm:^1.29.0":
+"@opentelemetry/semantic-conventions@npm:^1.28.0, @opentelemetry/semantic-conventions@npm:^1.29.0":
   version: 1.36.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.36.0"
   checksum: 10c0/edc8a6fe3ec4fc0c67ba3a92b86fb3dcc78fe1eb4f19838d8013c3232b9868540a034dd25cfe0afdd5eae752c5f0e9f42272ff46da144a2d5b35c644478e1c62
@@ -5199,18 +5168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "form-data@npm:4.0.1"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/bb102d570be8592c23f4ea72d7df9daa50c7792eb0cf1c5d7e506c1706e7426a4e4ae48a35b109e91c85f1c0ec63774a21ae252b66f4eb981cb8efef7d0463c8
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -5466,7 +5424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -7729,17 +7687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "minizlib@npm:3.0.1"
-  dependencies:
-    minipass: "npm:^7.0.4"
-    rimraf: "npm:^5.0.5"
-  checksum: 10c0/82f8bf70da8af656909a8ee299d7ed3b3372636749d29e105f97f20e88971be31f5ed7642f2e898f00283b68b701cc01307401cdc209b0efc5dd3818220e5093
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^3.1.0":
+"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
   version: 3.1.0
   resolution: "minizlib@npm:3.1.0"
   dependencies:
@@ -7761,15 +7709,6 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
   languageName: node
   linkType: hard
 
@@ -8886,7 +8825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.3, protobufjs@npm:^7.2.5, protobufjs@npm:^7.5.3":
+"protobufjs@npm:^7.2.3, protobufjs@npm:^7.5.3":
   version: 7.5.5
   resolution: "protobufjs@npm:7.5.5"
   dependencies:
@@ -9400,17 +9339,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^5.0.5":
-  version: 5.0.10
-  resolution: "rimraf@npm:5.0.10"
-  dependencies:
-    glob: "npm:^10.3.7"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: 10c0/7da4fd0e15118ee05b918359462cfa1e7fe4b1228c7765195a45b55576e8c15b95db513b8466ec89129666f4af45ad978a3057a02139afba1a63512a2d9644cc
-  languageName: node
-  linkType: hard
-
 "ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
   version: 2.0.2
   resolution: "ripemd160@npm:2.0.2"
@@ -9518,16 +9446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
-  version: 7.7.1
-  resolution: "semver@npm:7.7.1"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.2":
+"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.2":
   version: 7.7.2
   resolution: "semver@npm:7.7.2"
   bin:
@@ -10262,7 +10181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.0":
+"tar@npm:^7.4.0, tar@npm:^7.4.3":
   version: 7.5.12
   resolution: "tar@npm:7.5.12"
   dependencies:
@@ -10272,20 +10191,6 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/3825c5974f5fde792981f47ee9ffea021ee7f4b552b7ab95eeb98e5dfadfd5a5d5861f01fb772e2e5637a41980d3c019fd6cdad1be48b462b886abd7fe0fa17c
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.0.1"
-    mkdirp: "npm:^3.0.1"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves the dependabot security alerts that affect the published library. Closes the open dependabot PRs (#487, #488, #489, #490, #491, #498) in one bundle so they land coherently and CI passes (the originals failed because dependabot's lockfile changes don't survive yarn 4 hardened-mode post-resolution validation).

## Replace `uuid` with `crypto.randomUUID`

`crypto.randomUUID` has been available since Node `14.17`, the package requires Node >= `20`. This drops `uuid` and `@types/uuid` from both `db-client` and `test`.

- Replace `uuid.stringify` in `grpcUUID.ts` with a new   `structuredUUIDToString` helper that computes the canonical UUID string directly from the proto's msb/lsb int64 strings. The mask `& ((1n << 64n) - 1n)` reinterprets two's-complement negatives as unsigned, which incidentally fixes a latent bug: the previous `setBigUint64` path threw `RangeError` on any UUID whose first or 9th byte was >= 0x80.
- Add `packages/test/src/extra/grpcUUID.test.ts` covering `structuredUUIDToString` and `parseUUID`.

## Bump vulnerable transitives in yarn.lock

| Package                  | From    | To      | Severity |
| ------------------------ | ------- | ------- | -------- |
| protobufjs               | 7.4.0   | 7.5.5   | critical |
| axios                    | 1.7.9   | 1.15.1  | high     |
| follow-redirects         | 1.15.9  | 1.16.0  | medium   |
| protocol-buffers-schema  | 3.6.0   | 3.6.1   | medium   |

Cherry-picked from the open dependabot PRs, then `yarn install` to reconcile the lockfile. Followed by `yarn dedupe` for additional cleanup.
