### PR TITLE
fix: prevent unhandledRejection in batchAppend

### DIFF
--- a/packages/db-client/src/streams/appendToStream/batchAppend.ts
+++ b/packages/db-client/src/streams/appendToStream/batchAppend.ts
@@ -64,7 +64,13 @@ export const batchAppend = async function (
         )
         .on("data", (resp: BatchAppendResp) => {
           const resultingId = parseUUID(resp.getCorrelationId()!);
-          const [resolve, reject] = promiseBank.get(resultingId)!;
+          const entry = promiseBank.get(resultingId);
+
+          if (!entry) {
+            return;
+          }
+
+          const [resolve, reject] = entry;
 
           promiseBank.delete(resultingId);
 


### PR DESCRIPTION
We saw some unhandledRejections during client reconnect coming from this code. Stack below:

```
TypeError: undefined is not iterable (cannot read property
Symbol(Symbol.iterator))
at ClientDuplexStreamImpl.<anonymous>
(/opt/app/node_modules/.pnpm/@kurrent+kurrentdb-client@1.1.2/node_modules/@kurrent/kurrentdb-client/dist/streams/appendToStream/batchAppend.js:21:35)
at ClientDuplexStreamImpl.emit (node:events:508:28)
at addChunk (node:internal/streams/readable:563:12)
at readableAddChunkPushObjectMode (node:internal/streams/readable:540:3)
at Readable.push (node:internal/streams/readable:395:5)
at Object.onReceiveMessage
(/opt/app/node_modules/.pnpm/@grpc+grpc-js@1.14.3/node_modules/@grpc/grpc-js/build/src/client.js:411:24)
at Object.onReceiveMessage
(/opt/app/node_modules/.pnpm/@grpc+grpc-js@1.14.3/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:319:178)
at
/opt/app/node_modules/.pnpm/@grpc+grpc-js@1.14.3/node_modules/@grpc/grpc-js/build/src/resolving-call.js:213:39
at process.processTicksAndRejections
(node:internal/process/task_queues:104:5)
```