### PR TITLE
[DEV-1779] Fix event revision returned as a number instead of a bigint

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@eventstore/db-client": "^6.2.1",
-    "@kurrent/bridge": "^0.2.0",
+    "@kurrent/bridge": "^0.2.2",
     "tinybench": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/db-client/package.json
+++ b/packages/db-client/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.3",
-    "@kurrent/bridge": "^0.2.0",
+    "@kurrent/bridge": "^0.2.2",
     "@types/debug": "^4.1.12",
     "@types/google-protobuf": "^3.15.12",
     "@types/node": "^22.10.2",

--- a/packages/db-client/src/utils/convertRustEvent.ts
+++ b/packages/db-client/src/utils/convertRustEvent.ts
@@ -22,7 +22,7 @@ export const convertRustEvent = <T extends ResolvedEvent>(
   }
 
   if (rustClient.commitPosition != undefined) {
-    resolved.commitPosition = BigInt(rustClient.commitPosition);
+    resolved.commitPosition = rustClient.commitPosition;
   }
 
   return resolved as T;
@@ -63,16 +63,9 @@ export const convertRustRecord = <E extends EventType = EventType>(
   const metadata: E["metadata"] = parseMetadata(rustEvent, id);
   const isJson = rustEvent.isJson;
 
-  const position = {
-    commit:
-      rustEvent.position?.commit !== undefined
-        ? BigInt(rustEvent.position.commit)
-        : undefined,
-    prepare:
-      rustEvent.position?.prepare !== undefined
-        ? BigInt(rustEvent.position.prepare)
-        : undefined,
-  };
+  const position = rustEvent.position
+    ? { commit: rustEvent.position.commit, prepare: rustEvent.position.prepare }
+    : undefined;
 
   if (isJson) {
     const dataStr = Buffer.from(rustEvent.data).toString("utf8");

--- a/packages/test/src/extra/RecordedEvent-created.test.ts
+++ b/packages/test/src/extra/RecordedEvent-created.test.ts
@@ -18,7 +18,7 @@ describe("RecordedEvent created", () => {
     const STREAM_NAME = "test_stream_name";
     await client.appendToStream(STREAM_NAME, jsonTestEvents());
     for await (const { event } of client.readStream(STREAM_NAME)) {
-      expect(event).toBeDefined;
+      expect(event).toBeDefined();
       expect(event?.created).toBeInstanceOf(Date);
     }
   });

--- a/packages/test/src/streams/readStream.test.ts
+++ b/packages/test/src/streams/readStream.test.ts
@@ -89,6 +89,33 @@ describe("readStream", () => {
       });
     });
 
+    describe("runtime types", () => {
+      const readFirst = () =>
+        collect(
+          client.readStream(STREAM_NAME, {
+            maxCount: 1,
+            fromRevision: BigInt(1),
+          })
+        );
+
+      test("revision is a bigint", async () => {
+        const [resolved] = await readFirst();
+
+        expect(typeof resolved.event?.revision).toBe("bigint");
+        expect(resolved.event?.revision).toBe(BigInt(1));
+      });
+
+      const supported = matchServerVersion`>=22.6.0`;
+      optionalDescribe(supported)("log position (>=22.6.0)", () => {
+        test("position commit and prepare are bigint", async () => {
+          const [resolved] = await readFirst();
+
+          expect(typeof resolved.event?.position?.commit).toBe("bigint");
+          expect(typeof resolved.event?.position?.prepare).toBe("bigint");
+        });
+      });
+    });
+
     describe("options", () => {
       test("from start", async () => {
         let count = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,66 +1041,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-darwin-arm64@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-darwin-arm64@npm:0.2.0"
+"@kurrent/bridge-darwin-arm64@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-darwin-arm64@npm:0.2.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-darwin-x64@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-darwin-x64@npm:0.2.0"
+"@kurrent/bridge-darwin-x64@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-darwin-x64@npm:0.2.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-arm64-gnu@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-linux-arm64-gnu@npm:0.2.0"
+"@kurrent/bridge-linux-arm64-gnu@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-linux-arm64-gnu@npm:0.2.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-arm64-musl@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-linux-arm64-musl@npm:0.2.0"
+"@kurrent/bridge-linux-arm64-musl@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-linux-arm64-musl@npm:0.2.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-x64-gnu@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-linux-x64-gnu@npm:0.2.0"
+"@kurrent/bridge-linux-x64-gnu@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-linux-x64-gnu@npm:0.2.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-x64-musl@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-linux-x64-musl@npm:0.2.0"
+"@kurrent/bridge-linux-x64-musl@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-linux-x64-musl@npm:0.2.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-win32-x64-msvc@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge-win32-x64-msvc@npm:0.2.0"
+"@kurrent/bridge-win32-x64-msvc@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge-win32-x64-msvc@npm:0.2.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@kurrent/bridge@npm:0.2.0"
+"@kurrent/bridge@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@kurrent/bridge@npm:0.2.2"
   dependencies:
-    "@kurrent/bridge-darwin-arm64": "npm:0.2.0"
-    "@kurrent/bridge-darwin-x64": "npm:0.2.0"
-    "@kurrent/bridge-linux-arm64-gnu": "npm:0.2.0"
-    "@kurrent/bridge-linux-arm64-musl": "npm:0.2.0"
-    "@kurrent/bridge-linux-x64-gnu": "npm:0.2.0"
-    "@kurrent/bridge-linux-x64-musl": "npm:0.2.0"
-    "@kurrent/bridge-win32-x64-msvc": "npm:0.2.0"
+    "@kurrent/bridge-darwin-arm64": "npm:0.2.2"
+    "@kurrent/bridge-darwin-x64": "npm:0.2.2"
+    "@kurrent/bridge-linux-arm64-gnu": "npm:0.2.2"
+    "@kurrent/bridge-linux-arm64-musl": "npm:0.2.2"
+    "@kurrent/bridge-linux-x64-gnu": "npm:0.2.2"
+    "@kurrent/bridge-linux-x64-musl": "npm:0.2.2"
+    "@kurrent/bridge-win32-x64-msvc": "npm:0.2.2"
     "@neon-rs/load": "npm:^0.1.82"
   dependenciesMeta:
     "@kurrent/bridge-darwin-arm64":
@@ -1117,7 +1117,7 @@ __metadata:
       optional: true
     "@kurrent/bridge-win32-x64-msvc":
       optional: true
-  checksum: 10c0/fca00c46c8d9cc85006c5f34f167f4545aa0a5b3ec671f2a4907cded39a4175f8b0b9ec0e723078a285fd4cf0a1b1369d9e4c72febc36c64f54272256c58b7a2
+  checksum: 10c0/1f9034574fd9f6da30120605e9ec6eb50b590ad9c206029a703de405fba07c3b06b231eb6fe9a230be6b6c545e7e89a5beeb60f599022e6fe5888eee95ecdbf0
   languageName: node
   linkType: hard
 
@@ -1126,7 +1126,7 @@ __metadata:
   resolution: "@kurrent/kurrentdb-client@workspace:packages/db-client"
   dependencies:
     "@grpc/grpc-js": "npm:^1.14.3"
-    "@kurrent/bridge": "npm:^0.2.0"
+    "@kurrent/bridge": "npm:^0.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/google-protobuf": "npm:^3.15.12"
     "@types/node": "npm:^22.10.2"
@@ -2693,7 +2693,7 @@ __metadata:
   resolution: "benchmark@workspace:packages/benchmark"
   dependencies:
     "@eventstore/db-client": "npm:^6.2.1"
-    "@kurrent/bridge": "npm:^0.2.0"
+    "@kurrent/bridge": "npm:^0.2.2"
     "@kurrent/kurrentdb-client": "workspace:^"
     clinic: "npm:^13.0.0"
     tinybench: "npm:^3.1.1"


### PR DESCRIPTION
`resolvedEvent.event.revision` is now a `bigint` at runtime, matching its declared type. It was previously a `number`, so `revision === 0n` returned false and `revision + 1n` threw.

Closes #513