### PR TITLE
[DEV-1818] Fix batchAppend cross-stream error contamination

### DIFF
--- a/packages/db-client/src/streams/appendToStream/batchAppend.ts
+++ b/packages/db-client/src/streams/appendToStream/batchAppend.ts
@@ -30,14 +30,19 @@ import {
 
 import type { AppendToStreamOptions } from ".";
 
+type PromiseBank = Map<
+  string,
+  [resolve: (r: AppendResult) => void, reject: (error: Error) => void]
+>;
+
 const streamCache = new WeakMap<
   StreamsClient,
   Promise<ReturnType<StreamsClient["batchAppend"]>>
 >();
 
-const promiseBank = new Map<
-  string,
-  [resolve: (r: AppendResult) => void, reject: (error: Error) => void]
+const promiseBanks = new WeakMap<
+  ReturnType<StreamsClient["batchAppend"]>,
+  PromiseBank
 >();
 
 export const batchAppend = async function (
@@ -55,8 +60,10 @@ export const batchAppend = async function (
   const stream = await this.GRPCStreamCreator(
     StreamsClient,
     "appendToStream",
-    (client) =>
-      client
+    (client) => {
+      const promiseBank: PromiseBank = new Map();
+
+      const batchStream = client
         .batchAppend(
           ...this.callArguments(baseOptions, {
             deadline: Infinity,
@@ -64,8 +71,11 @@ export const batchAppend = async function (
         )
         .on("data", (resp: BatchAppendResp) => {
           const resultingId = parseUUID(resp.getCorrelationId()!);
-          const [resolve, reject] = promiseBank.get(resultingId)!;
+          const entry = promiseBank.get(resultingId);
 
+          if (!entry) return;
+
+          const [resolve, reject] = entry;
           promiseBank.delete(resultingId);
 
           if (resp.hasError()) {
@@ -120,9 +130,21 @@ export const batchAppend = async function (
             reject(convertToCommandError(error));
           }
           promiseBank.clear();
-        }),
+        });
+
+      promiseBanks.set(batchStream, promiseBank);
+
+      return batchStream;
+    },
     streamCache
   )();
+
+  const promiseBank = promiseBanks.get(stream);
+  if (!promiseBank) {
+    throw new Error(
+      "batchAppend could not find the promise bank for the stream."
+    );
+  }
 
   return new Promise(async (...batchPromise) => {
     promiseBank.set(correlationId, batchPromise);

--- a/packages/db-client/src/streams/appendToStream/batchAppend.ts
+++ b/packages/db-client/src/streams/appendToStream/batchAppend.ts
@@ -73,7 +73,13 @@ export const batchAppend = async function (
           const resultingId = parseUUID(resp.getCorrelationId()!);
           const entry = promiseBank.get(resultingId);
 
-          if (!entry) return;
+          if (!entry) {
+            debug.command_grpc(
+              "batchAppend: dropping response for unknown correlationId %s",
+              resultingId
+            );
+            return;
+          }
 
           const [resolve, reject] = entry;
           promiseBank.delete(resultingId);

--- a/packages/test/src/streams/appendToStream-batch-append.test.ts
+++ b/packages/test/src/streams/appendToStream-batch-append.test.ts
@@ -111,6 +111,40 @@ describe("appendToStream - batch append", () => {
         (128 * 5_000) / 1024
       );
     });
+
+    test("A stream error does not reject in-flight appends on sibling streams", async () => {
+      const clientA = KurrentDBClient.connectionString(node.connectionString());
+      const clientB = KurrentDBClient.connectionString(node.connectionString());
+      const aSpy = jest.spyOn(
+        clientA,
+        "GRPCStreamCreator" as never
+      ) as unknown as jest.SpiedFunction<KurrentDBClient["GRPCStreamCreator"]>;
+
+      try {
+        await clientA.appendToStream("sibling_a_warmup", jsonTestEvents());
+        await clientB.appendToStream("sibling_b_warmup", jsonTestEvents());
+
+        const aStream = await extractBatchStream.call(
+          clientA,
+          ...aSpy.mock.calls[0]
+        );
+
+        const bAppend = clientB.appendToStream(
+          "sibling_b_during_a_error",
+          jsonTestEvents()
+        );
+
+        await new Promise((r) => setImmediate(r));
+
+        aStream.emit("error", new Error("simulated transport error"));
+
+        const bResult = await bAppend;
+        expect(bResult.success).toBe(true);
+      } finally {
+        await clientA.dispose();
+        await clientB.dispose();
+      }
+    });
   });
 });
 

--- a/packages/test/src/streams/appendToStream-batch-append.test.ts
+++ b/packages/test/src/streams/appendToStream-batch-append.test.ts
@@ -129,14 +129,27 @@ describe("appendToStream - batch append", () => {
           ...aSpy.mock.calls[0]
         );
 
-        const bAppend = clientB.appendToStream(
-          "sibling_b_during_a_error",
-          jsonTestEvents()
-        );
+        let aSettled = false;
+        let bSettled = false;
+        const aAppend = clientA
+          .appendToStream("sibling_a_during_a_error", jsonTestEvents())
+          .finally(() => {
+            aSettled = true;
+          });
+        const bAppend = clientB
+          .appendToStream("sibling_b_during_a_error", jsonTestEvents())
+          .finally(() => {
+            bSettled = true;
+          });
 
         await new Promise((r) => setImmediate(r));
 
+        expect(aSettled).toBe(false);
+        expect(bSettled).toBe(false);
+
         aStream.emit("error", new Error("simulated transport error"));
+
+        await expect(aAppend).rejects.toThrow();
 
         const bResult = await bAppend;
         expect(bResult.success).toBe(true);


### PR DESCRIPTION
`batchAppend` used a single process-global promise bank shared by every client and stream. A transport error on one stream rejected and cleared in-flight appends belonging to unrelated streams, and a late `data` response after the bank was cleared crashed with `TypeError: undefined is not iterable`.

Each stream now owns its own promise bank, so an error only affects appends on the stream that actually failed. A `data` response with no matching correlation id is dropped (and logged via `debug.command_grpc`) instead of crashing.

Regression test asserts that when one stream errors:
- a sibling stream's in-flight append still succeeds, and
- the erroring stream's own in-flight append rejects.

Both appends are asserted still-pending immediately before the error is emitted, so a fast server response surfaces as a failure rather than a silent pass.